### PR TITLE
Implement MarketError and tidy comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,4 @@ name = "the_market"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod market {
+    /// Error type for market operations
     #[derive(PartialEq)]
     #[derive(Debug)]
     pub struct MarketError {
@@ -6,8 +7,8 @@ pub mod market {
     }
 
     impl MarketError {
-        pub fn new<S: Into<String>>(error: S) -> Self {
-            Self { error: error.into() }
+        pub fn new(error: String) -> Self {
+            Self { error }
         }
     }
 


### PR DESCRIPTION
## Summary
- implement constructor for `MarketError`
- remove outdated Cargo comments
- document the custom error type

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686125e7c11883288670b39b0afe6e61