### PR TITLE
Add resolve_orders empty market test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,4 +340,13 @@ mod market_behavior{
 
         assert!(result.is_err());
     }
+
+    #[test]
+    fn resolve_orders_returns_error_on_empty_market() {
+        let mut market = market::Market::new();
+
+        let result = market.resolve_orders();
+
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- add a new unit test exercising `Market::resolve_orders` on a fresh market
- verify it returns `Err(MarketError)`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686126b103a48328a6e41e85afbb8d4f